### PR TITLE
Migrate to Express 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
+    "body-parser": "^1.13.3",
+    "cookie-parser": "^1.3.5",
+    "cookie-session": "^1.2.0",
     "request": "*",
     "express": "*",
     "ejs": "*"

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "easypeasy",
+  "name": "node.js-persona-example",
   "description": "A minimalist Persona Implementation in Node.JS",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "dependencies": {
     "body-parser": "^1.13.3",
     "cookie-parser": "^1.3.5",
     "cookie-session": "^1.2.0",
     "request": "*",
-    "express": "*",
+    "express": "^4.13.3",
     "ejs": "*"
   },
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -3,9 +3,9 @@ var express = require('express'),
 
 var app = express();
 
-app.use(express.cookieParser())
-   .use(express.bodyParser())
-   .use(express.cookieSession({
+app.use(require('cookie-parser')())
+   .use(require('body-parser').urlencoded({ extended: true }))
+   .use(require('cookie-session')({
      secret: "meh"
    }))
    .use(express.static(__dirname + '/static'));


### PR DESCRIPTION
The cookieParser, bodyParser, cookieSession middleware have been taken out of the Express code base (http://expressjs.com/guide/migrating-4.html). This change loads them as independent modules.
